### PR TITLE
net/sched: add action inheritdsfield to skbmod

### DIFF
--- a/include/uapi/linux/tc_act/tc_skbmod.h
+++ b/include/uapi/linux/tc_act/tc_skbmod.h
@@ -19,6 +19,7 @@
 #define SKBMOD_F_SMAC	0x2
 #define SKBMOD_F_ETYPE	0x4
 #define SKBMOD_F_SWAPMAC 0x8
+#define SKBMOD_F_INHERITDSFIELD 0x10
 
 struct tc_skbmod {
 	tc_gen;


### PR DESCRIPTION
This patch is an extension to skbmod to mark skbprio based on ds field.